### PR TITLE
accept/rejectのフォールスルーを修正

### DIFF
--- a/src/components/SimpleP2P.vue
+++ b/src/components/SimpleP2P.vue
@@ -249,9 +249,11 @@ export default class P2P extends Vue {
         } else {
           console.warn('peer already exist.');
         }
+        break;
       case 'reject':
         console.log('Received Reject ...', message);
         this.disconnect();
+        break;
       case 'offer':
         console.log('Received offer ...', message);
         this.setOffer(message);


### PR DESCRIPTION
onWsMessage関数のswitch文で意図しないフォロースルーにより、
case 'accept' でaccept/reject/offerの全処理が走ってしまっていたので修正。
よければ取り込んで下さい。